### PR TITLE
Fixed creating function updatecacheitemformat

### DIFF
--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Function_UpdateCacheItemFormat.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Function_UpdateCacheItemFormat.sql
@@ -28,7 +28,7 @@ v_Query := format('UPDATE %I.%I ' ||
   				  'AND "SlidingExpirationInSeconds" IS NOT NULL ' ||
   				  'AND ("AbsoluteExpiration" IS NULL OR "AbsoluteExpiration" <> "ExpiresAtTime")', "SchemaName", "TableName", "SchemaName");
 EXECUTE v_Query using "UtcNow", "DistCacheId";   
-RAISE NOTICE '[schemaName].updatecacheitemformat UPDATED entry for Id: ', "DistCacheId";
+RAISE NOTICE '[schemaName].updatecacheitemformat UPDATED entry for Id: %', "DistCacheId";
 END
 $function$;
 


### PR DESCRIPTION
Package was not working because of missing % placeholder for RAISE NOTICE parameter. 

At least under PostgreSql v14 and .NET 6 it fails to start and nothing is created. With this fix, everything is fine.