### PR TITLE
migrated to netstandard2.0, added support for net7.0, postgres 11+

### DIFF
--- a/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
+++ b/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="16.0">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Community.Microsoft.Extensions.Caching.PostgreSql</AssemblyName>
     <RootNamespace>Community.Microsoft.Extensions.Caching.PostgreSql</RootNamespace>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -15,29 +15,22 @@
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="PostgreSqlScripts\Create_Function_DateDiff.sql" />
-    <EmbeddedResource Include="PostgreSqlScripts\Create_Function_DeleteCacheItemFormat.sql" />
-    <EmbeddedResource Include="PostgreSqlScripts\Create_Function_DeleteExpiredCacheItemsFormat.sql" />
     <EmbeddedResource Include="PostgreSqlScripts\Create_Function_GetCacheItemFormat.sql" />
-    <EmbeddedResource Include="PostgreSqlScripts\Create_Function_SetCache.sql" />
-    <EmbeddedResource Include="PostgreSqlScripts\Create_Function_UpdateCacheItemFormat.sql" />
+    <EmbeddedResource Include="PostgreSqlScripts\Create_Procedure_DeleteCacheItemFormat.sql" />
+    <EmbeddedResource Include="PostgreSqlScripts\Create_Procedure_DeleteExpiredCacheItemsFormat.sql" />
+    <EmbeddedResource Include="PostgreSqlScripts\Create_Procedure_SetCache.sql" />
+    <EmbeddedResource Include="PostgreSqlScripts\Create_Procedure_UpdateCacheItemFormat.sql" />
     <EmbeddedResource Include="PostgreSqlScripts\Create_Table_DistCache.sql" />
   </ItemGroup>
   <!--<ItemGroup>
     <Compile Include="**\*.cs" />
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'" >
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Npgsql" Version="6.0.1" />
-  </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'" >
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="Npgsql" Version="5.0.11" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
+    <PackageReference Include="Npgsql" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
+++ b/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
@@ -4,11 +4,11 @@
     <AssemblyName>Community.Microsoft.Extensions.Caching.PostgreSql</AssemblyName>
     <RootNamespace>Community.Microsoft.Extensions.Caching.PostgreSql</RootNamespace>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.1.1</Version>
+    <Version>4.0.0</Version>
     <Authors>Ashley Marques</Authors>
     <Company />
     <Description>DistributedCache using postgres</Description>
-    <PackageReleaseNotes>Dependencies updated to latest and now multitarget .net5 and .net6</PackageReleaseNotes>
+    <PackageReleaseNotes>Dependencies updated to latest and now multitarget netstandard2.0 and .net7</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/leonibr/community-extensions-cache-postgres</PackageProjectUrl>
     <RepositoryUrl>https://github.com/leonibr/community-extensions-cache-postgres.git</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>

--- a/Extensions.Caching.PostgreSql/DatabaseOperations.cs
+++ b/Extensions.Caching.PostgreSql/DatabaseOperations.cs
@@ -86,21 +86,21 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
             var sql = (
              table: ReadScript("Create_Table_DistCache.sql"),
              funcDateDiff: ReadScript("Create_Function_DateDiff.sql"),
-             funcDeleteCacheItem: ReadScript("Create_Function_DeleteCacheItemFormat.sql"),
-             funcDeleteExpired: ReadScript("Create_Function_DeleteExpiredCacheItemsFormat.sql"),
              funcGetCacheItem: ReadScript("Create_Function_GetCacheItemFormat.sql"),
-             funcSetCache: ReadScript("Create_Function_SetCache.sql"),
-             funcUpdateCache: ReadScript("Create_Function_UpdateCacheItemFormat.sql")
+             procDeleteCacheItem: ReadScript("Create_Procedure_DeleteCacheItemFormat.sql"),
+             procDeleteExpired: ReadScript("Create_Procedure_DeleteExpiredCacheItemsFormat.sql"),
+             procSetCache: ReadScript("Create_Procedure_SetCache.sql"),
+             procUpdateCache: ReadScript("Create_Procedure_UpdateCacheItemFormat.sql")
              );
 
             var sb = new StringBuilder()
                 .Append(FormatName(sql.table))
                 .Append(FormatName(sql.funcDateDiff))
                 .Append(FormatName(sql.funcGetCacheItem))
-                .Append(FormatName(sql.funcSetCache))
-                .Append(FormatName(sql.funcUpdateCache))
-                .Append(FormatName(sql.funcDeleteCacheItem))
-                .Append(FormatName(sql.funcDeleteExpired));
+                .Append(FormatName(sql.procSetCache))
+                .Append(FormatName(sql.procUpdateCache))
+                .Append(FormatName(sql.procDeleteCacheItem))
+                .Append(FormatName(sql.procDeleteExpired));
 
             using (var cn = new NpgsqlConnection(ConnectionString))
             {
@@ -137,10 +137,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
         {
             using (var connection = new NpgsqlConnection(ConnectionString))
             {
-                var command = new NpgsqlCommand($"{SchemaName}.{Functions.Names.DeleteCacheItemFormat}", connection)
-                {
-                    CommandType = CommandType.StoredProcedure
-                };
+                var command = CreateProcedureCallCommand(Functions.Names.DeleteCacheItemFormat, connection);
                 command.Parameters
                     .AddParamWithValue("SchemaName", NpgsqlTypes.NpgsqlDbType.Text, SchemaName)
                     .AddParamWithValue("TableName", NpgsqlTypes.NpgsqlDbType.Text, TableName)
@@ -159,10 +156,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
         {
             using (var connection = new NpgsqlConnection(ConnectionString))
             {
-                var command = new NpgsqlCommand($"{SchemaName}.{Functions.Names.DeleteCacheItemFormat}", connection)
-                {
-                    CommandType = CommandType.StoredProcedure
-                };
+                var command = CreateProcedureCallCommand(Functions.Names.DeleteCacheItemFormat, connection);
                 command.Parameters
                     .AddParamWithValue("SchemaName", NpgsqlTypes.NpgsqlDbType.Text, SchemaName)
                     .AddParamWithValue("TableName", NpgsqlTypes.NpgsqlDbType.Text, TableName)
@@ -204,10 +198,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
             using (var connection = new NpgsqlConnection(ConnectionString))
             {
                 connection.Notice += LogNotice;
-                var command = new NpgsqlCommand($"{SchemaName}.{Functions.Names.DeleteExpiredCacheItemsFormat}", connection)
-                {
-                    CommandType = CommandType.StoredProcedure
-                };
+                var command = CreateProcedureCallCommand(Functions.Names.DeleteExpiredCacheItemsFormat, connection);
                 command.Parameters
                     .AddParamWithValue("SchemaName", NpgsqlTypes.NpgsqlDbType.Text, SchemaName)
                     .AddParamWithValue("TableName", NpgsqlTypes.NpgsqlDbType.Text, TableName)
@@ -231,10 +222,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
 
             using (var connection = new NpgsqlConnection(ConnectionString))
             {
-                var command = new NpgsqlCommand($"{SchemaName}.{Functions.Names.SetCache}", connection)
-                {
-                    CommandType = CommandType.StoredProcedure
-                };
+                var command = CreateProcedureCallCommand(Functions.Names.SetCache, connection);
                 command.Parameters
                     .AddParamWithValue("SchemaName", NpgsqlTypes.NpgsqlDbType.Text, SchemaName)
                     .AddParamWithValue("TableName", NpgsqlTypes.NpgsqlDbType.Text, TableName)
@@ -256,7 +244,6 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
                     {
                         // There is a possibility that multiple requests can try to add the same item to the cache, in
                         // which case we receive a 'duplicate key' exception on the primary key column.
-                        logger.LogError(exception: ex, $"Duplicate key, it already exists key: {key}");
                     }
                     else
                     {
@@ -275,10 +262,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
 
             using (var connection = new NpgsqlConnection(ConnectionString))
             {
-                var command = new NpgsqlCommand($"{SchemaName}.{Functions.Names.SetCache}", connection)
-                {
-                    CommandType = CommandType.StoredProcedure
-                };
+                var command = CreateProcedureCallCommand(Functions.Names.SetCache, connection);
                 command.Parameters
                     .AddParamWithValue("SchemaName", NpgsqlTypes.NpgsqlDbType.Text, SchemaName)
                     .AddParamWithValue("TableName", NpgsqlTypes.NpgsqlDbType.Text, TableName)
@@ -319,10 +303,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
             using (var connection = new NpgsqlConnection(ConnectionString))
             {
                 connection.Notice += LogNotice;
-                var command = new NpgsqlCommand($"{SchemaName}.{Functions.Names.UpdateCacheItemFormat}", connection)
-                {
-                    CommandType = CommandType.StoredProcedure
-                };
+                var command = CreateProcedureCallCommand(Functions.Names.UpdateCacheItemFormat, connection);
                 command.Parameters
                     .AddParamWithValue("SchemaName", NpgsqlTypes.NpgsqlDbType.Text, SchemaName)
                     .AddParamWithValue("TableName", NpgsqlTypes.NpgsqlDbType.Text, TableName)
@@ -334,10 +315,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
 
                 if (includeValue)
                 {
-                    command = new NpgsqlCommand($"{SchemaName}.{Functions.Names.GetCacheItemFormat}", connection)
-                    {
-                        CommandType = CommandType.StoredProcedure
-                    };
+                    command = CreateGetCacheItemFunctionCallCommand(connection);
                     command.Parameters
                         .AddParamWithValue("SchemaName", NpgsqlTypes.NpgsqlDbType.Text, SchemaName)
                         .AddParamWithValue("TableName", NpgsqlTypes.NpgsqlDbType.Text, TableName)
@@ -381,10 +359,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
             using (var connection = new NpgsqlConnection(ConnectionString))
             {
                 connection.Notice += LogNotice;
-                var command = new NpgsqlCommand($"{SchemaName}.{Functions.Names.UpdateCacheItemFormat}", connection)
-                {
-                    CommandType = CommandType.StoredProcedure
-                };
+                var command = CreateProcedureCallCommand(Functions.Names.UpdateCacheItemFormat, connection);
                 command.Parameters
                    .AddParamWithValue("SchemaName", NpgsqlTypes.NpgsqlDbType.Text, SchemaName)
                    .AddParamWithValue("TableName", NpgsqlTypes.NpgsqlDbType.Text, TableName)
@@ -396,16 +371,12 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
 
                 if (includeValue)
                 {
-                    command = new NpgsqlCommand($"{SchemaName}.{Functions.Names.GetCacheItemFormat}", connection)
-                    {
-                        CommandType = CommandType.StoredProcedure
-                    };
+                    command = CreateGetCacheItemFunctionCallCommand(connection);
                     command.Parameters
                         .AddParamWithValue("SchemaName", NpgsqlTypes.NpgsqlDbType.Text, SchemaName)
                         .AddParamWithValue("TableName", NpgsqlTypes.NpgsqlDbType.Text, TableName)
                         .AddCacheItemId(key)
                         .AddWithValue("UtcNow", NpgsqlTypes.NpgsqlDbType.TimestampTz, utcNow);
-
 
                     var reader = await command.ExecuteReaderAsync(
                         CommandBehavior.SequentialAccess | CommandBehavior.SingleRow | CommandBehavior.SingleResult,
@@ -471,6 +442,23 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
                 throw new InvalidOperationException("Either absolute or sliding expiration needs " +
                     "to be provided.");
             }
+        }
+
+        private NpgsqlCommand CreateProcedureCallCommand(
+            string functionName,
+            NpgsqlConnection connection)
+        {
+            return new NpgsqlCommand($"{SchemaName}.{functionName}", connection)
+            {
+                CommandType = CommandType.StoredProcedure
+            };
+        }
+
+        private NpgsqlCommand CreateGetCacheItemFunctionCallCommand(NpgsqlConnection connection)
+        {
+            return new NpgsqlCommand(
+                $"SELECT * FROM {SchemaName}.{Functions.Names.GetCacheItemFormat}(@SchemaName, @TableName, @{Columns.Names.CacheItemId}, @UtcNow)",
+                connection);
         }
     }
 }

--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_DeleteCacheItemFormat.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_DeleteCacheItemFormat.sql
@@ -1,6 +1,6 @@
--- FUNCTION: public.deletecacheitemformat(text, text, text)
+-- PROCEDURE: public.deletecacheitemformat(text, text, text)
 
--- DROP FUNCTION public.deletecacheitemformat(text, text, text);
+-- DROP PROCEDURE public.deletecacheitemformat(text, text, text);
 
 CREATE OR REPLACE PROCEDURE [schemaName].deletecacheitemformat(
 	"SchemaName" text,

--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_DeleteCacheItemFormat.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_DeleteCacheItemFormat.sql
@@ -2,15 +2,12 @@
 
 -- DROP FUNCTION public.deletecacheitemformat(text, text, text);
 
-CREATE OR REPLACE FUNCTION [schemaName].deletecacheitemformat(
+CREATE OR REPLACE PROCEDURE [schemaName].deletecacheitemformat(
 	"SchemaName" text,
 	"TableName" text,
 	"DistCacheId" text)
-    RETURNS void
     LANGUAGE 'plpgsql'
-    COST 100.0
-    VOLATILE NOT LEAKPROOF 
-AS $function$
+AS $$
 
     
 DECLARE v_Query Text;
@@ -30,5 +27,5 @@ if v_Hit = false then
 end if;
 END
 
-$function$;
+$$;
 

--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_DeleteExpiredCacheItemsFormat.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_DeleteExpiredCacheItemsFormat.sql
@@ -1,6 +1,6 @@
--- FUNCTION: public.deleteexpiredcacheitemsformat(text, text, timestamp with time zone)
+-- PROCEDURE: public.deleteexpiredcacheitemsformat(text, text, timestamp with time zone)
 
--- DROP FUNCTION public.deleteexpiredcacheitemsformat(text, text, timestamp with time zone);
+-- DROP PROCEDURE public.deleteexpiredcacheitemsformat(text, text, timestamp with time zone);
 
 CREATE OR REPLACE PROCEDURE [schemaName].deleteexpiredcacheitemsformat(
 	"SchemaName" text,

--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_DeleteExpiredCacheItemsFormat.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_DeleteExpiredCacheItemsFormat.sql
@@ -2,15 +2,12 @@
 
 -- DROP FUNCTION public.deleteexpiredcacheitemsformat(text, text, timestamp with time zone);
 
-CREATE OR REPLACE FUNCTION [schemaName].deleteexpiredcacheitemsformat(
+CREATE OR REPLACE PROCEDURE [schemaName].deleteexpiredcacheitemsformat(
 	"SchemaName" text,
 	"TableName" text,
 	"UtcNow" timestamp with time zone)
-    RETURNS void
     LANGUAGE 'plpgsql'
-    COST 100.0
-    VOLATILE NOT LEAKPROOF 
-AS $function$
+AS $$
 
 DECLARE v_Query Text;
 DECLARE v_RowCount INT;
@@ -23,5 +20,5 @@ RAISE NOTICE '[schemaName].deleteexpiredcacheitemsformat - DELETED - % entreis',
     
 END
 
-$function$;
+$$;
 

--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_SetCache.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_SetCache.sql
@@ -2,7 +2,7 @@
 
 -- DROP FUNCTION public.setcache(text, text, text, bytea, double precision, timestamp with time zone, timestamp with time zone);
 
-CREATE OR REPLACE FUNCTION [schemaName].setcache(
+CREATE OR REPLACE PROCEDURE [schemaName].setcache(
 	"SchemaName" text,
 	"TableName" text,
 	"DistCacheId" text,
@@ -10,11 +10,8 @@ CREATE OR REPLACE FUNCTION [schemaName].setcache(
 	"DistCacheSlidingExpirationInSeconds" double precision,
 	"DistCacheAbsoluteExpiration" timestamp with time zone,
 	"UtcNow" timestamp with time zone)
-    RETURNS void
     LANGUAGE 'plpgsql'
-    COST 100.0
-    VOLATILE NOT LEAKPROOF 
-AS $function$
+AS $$
 
 DECLARE v_ExpiresAtTime TIMESTAMP(6) WITH TIME ZONE;
 DECLARE v_RowCount INT;
@@ -42,4 +39,4 @@ ELSE
 END IF;
 END
 
-$function$;
+$$;

--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_SetCache.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_SetCache.sql
@@ -1,6 +1,6 @@
--- FUNCTION: public.setcache(text, text, text, bytea, double precision, timestamp with time zone, timestamp with time zone)
+-- PROCEDURE: public.setcache(text, text, text, bytea, double precision, timestamp with time zone, timestamp with time zone)
 
--- DROP FUNCTION public.setcache(text, text, text, bytea, double precision, timestamp with time zone, timestamp with time zone);
+-- DROP PROCEDURE public.setcache(text, text, text, bytea, double precision, timestamp with time zone, timestamp with time zone);
 
 CREATE OR REPLACE PROCEDURE [schemaName].setcache(
 	"SchemaName" text,

--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_UpdateCacheItemFormat.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_UpdateCacheItemFormat.sql
@@ -2,16 +2,13 @@
 
 -- DROP FUNCTION public.updatecacheitemformat(text, text, text, timestamp with time zone);
 
-CREATE OR REPLACE FUNCTION [schemaName].updatecacheitemformat(
+CREATE OR REPLACE PROCEDURE [schemaName].updatecacheitemformat(
 	"SchemaName" text,
 	"TableName" text,
 	"DistCacheId" text,
 	"UtcNow" timestamp with time zone)
-    RETURNS void
     LANGUAGE 'plpgsql'
-    COST 100.0
-    VOLATILE NOT LEAKPROOF 
-AS $function$
+AS $$
 
 DECLARE v_Query Text;
 BEGIN
@@ -30,5 +27,5 @@ v_Query := format('UPDATE %I.%I ' ||
 EXECUTE v_Query using "UtcNow", "DistCacheId";   
 RAISE NOTICE '[schemaName].updatecacheitemformat UPDATED entry for Id: %', "DistCacheId";
 END
-$function$;
+$$;
 

--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_UpdateCacheItemFormat.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Procedure_UpdateCacheItemFormat.sql
@@ -1,6 +1,6 @@
--- FUNCTION: public.updatecacheitemformat(text, text, text, timestamp with time zone)
+-- PROCEDURE: public.updatecacheitemformat(text, text, text, timestamp with time zone)
 
--- DROP FUNCTION public.updatecacheitemformat(text, text, text, timestamp with time zone);
+-- DROP PROCEDURE public.updatecacheitemformat(text, text, text, timestamp with time zone);
 
 CREATE OR REPLACE PROCEDURE [schemaName].updatecacheitemformat(
 	"SchemaName" text,

--- a/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Table_DistCache.sql
+++ b/Extensions.Caching.PostgreSql/PostgreSqlScripts/Create_Table_DistCache.sql
@@ -1,4 +1,4 @@
--- Table: [schemaName]."DistCache"
+-- Table: [schemaName].[tableName]
 
 
 CREATE SCHEMA IF NOT EXISTS [schemaName];

--- a/PostgreSqlCacheSample/PostgreSqlCacheSample.csproj
+++ b/PostgreSqlCacheSample/PostgreSqlCacheSample.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>dotnet-PostgreSqlCacheSample-F04BB98E-2126-4C2F-B086-66C8CC6AA428</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PostgreSqlCacheSample/Program.cs
+++ b/PostgreSqlCacheSample/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Community.Microsoft.Extensions.Caching.PostgreSql;
+using Microsoft.Extensions.Configuration;
 
 namespace PostgreSqlCacheSample
 {
@@ -20,7 +21,8 @@ namespace PostgreSqlCacheSample
 						setup.ConnectionString = configuration["ConnectionString"];
 						setup.SchemaName = configuration["SchemaName"];
 						setup.TableName = configuration["TableName"];
-                        // CreateInfrastructure is optional, default is TRUE
+						setup.CreateInfrastructure = configuration.GetValue<bool>("CreateInfrastructure");
+						// CreateInfrastructure is optional, default is TRUE
 						// This means que every time starts the application the 
 						// creation of table and database functions will be verified.
 					})

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ dotnet add package Community.Microsoft.Extensions.Caching.PostgreSql
 ```c#
 services.AddDistributedPostgreSqlCache(setup => 
 {
-	setup.ConnectionString = configuration["ConnectionString"];
-	setup.SchemaName = configuration["SchemaName"];
-	setup.TableName = configuration["TableName"];
-	setup.DisableRemoveExpired = configuration["DisableRemoveExpired"];
+    setup.ConnectionString = configuration["ConnectionString"];
+    setup.SchemaName = configuration["SchemaName"];
+    setup.TableName = configuration["TableName"];
+    setup.DisableRemoveExpired = configuration["DisableRemoveExpired"];
     // Optional - DisableRemoveExpired default is FALSE
-	setup.CreateInfrastructure = configuration["CreateInfrastructure"];
-	// CreateInfrastructure is optional, default is TRUE
-	// This means que every time starts the application the 
-	// creation of table and database functions will be verified.
-	setup.ExpiredItemsDeletionInterval = TimeSpan.FromMinutes(30)
-	// ExpiredItemsDeletionInterval is optional
+    setup.CreateInfrastructure = configuration["CreateInfrastructure"];
+    // CreateInfrastructure is optional, default is TRUE
+    // This means que every time starts the application the 
+    // creation of table and database functions will be verified.
+    setup.ExpiredItemsDeletionInterval = TimeSpan.FromMinutes(30)
+    // ExpiredItemsDeletionInterval is optional
     // This is the periodic interval to scan and delete expired items in the cache. Default is 30 minutes. 
     // Minimum allowed is 5 minutes. - If you need less than this please share your use case 😁, just for curiosity...
 })
@@ -50,16 +50,21 @@ In that case you are responsable to manually remove the expired key or update it
 ```
 ## What it does to my database 🐘: 
 
-Creates a table and six functions, see scripts folder for more details.
+1) Creates a table (name is configurable)
+2) Creates two functions
 ```
 [schemaName].datediff
+[schemaName].getcacheitemformat
+```
+3) Creates four stored procedures
+```
 [schemaName].deletecacheitemformat
 [schemaName].deleteexpiredcacheitemsformat
-[schemaName].getcacheitemformat
 [schemaName].setcache
 [schemaName].updatecacheitemformat
-
 ```
+
+For additional details please check the [scripts folder](./Extensions.Caching.PostgreSql/PostgreSqlScripts).
 
 ## Runing the console sample
 You will need a local postgresql server with this configuration:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
-﻿
-# Community.Microsoft.Extensions.Caching.PostgreSQL
+﻿# Community.Microsoft.Extensions.Caching.PostgreSQL
 
 ## Description
 
-This implemantation uses PostgreSQL as distributed cache.
+This implemantation uses PostgreSQL 11+ as distributed cache. Version 4 and up.
+
+### For PostgreSQL <= 10
+
+Use older versions of this packages (<= 3.1.2)
 
 ## Getting Started
+
 1. Install the package into your project
+
 ```
 dotnet add package Community.Microsoft.Extensions.Caching.PostgreSql
 ```
-2. Add the following line to the `Startup`  `Configure` method.
+
+2. Add the following line to the `Startup` `Configure` method.
+
 ```c#
-services.AddDistributedPostgreSqlCache(setup => 
+services.AddDistributedPostgreSqlCache(setup =>
 {
     setup.ConnectionString = configuration["ConnectionString"];
     setup.SchemaName = configuration["SchemaName"];
@@ -21,19 +28,22 @@ services.AddDistributedPostgreSqlCache(setup =>
     // Optional - DisableRemoveExpired default is FALSE
     setup.CreateInfrastructure = configuration["CreateInfrastructure"];
     // CreateInfrastructure is optional, default is TRUE
-    // This means que every time starts the application the 
+    // This means que every time starts the application the
     // creation of table and database functions will be verified.
     setup.ExpiredItemsDeletionInterval = TimeSpan.FromMinutes(30)
     // ExpiredItemsDeletionInterval is optional
-    // This is the periodic interval to scan and delete expired items in the cache. Default is 30 minutes. 
+    // This is the periodic interval to scan and delete expired items in the cache. Default is 30 minutes.
     // Minimum allowed is 5 minutes. - If you need less than this please share your use case 😁, just for curiosity...
 })
 ```
+
 ### `DisableRemoveExpired = True` use case:
-When you have 2 or more instances/microservices/processes and you just to leave one of them removing expired items. 
-* Note 1: This is not mandatory, see if it fits in you cenario.
-* Note 2: If you have only one instance and set to `True`, all the expired items will not be auto-removed, when you call `GetItem` those expired items are filtred out.
-In that case you are responsable to manually remove the expired key or update it
+
+When you have 2 or more instances/microservices/processes and you just to leave one of them removing expired items.
+
+- Note 1: This is not mandatory, see if it fits in you cenario.
+- Note 2: If you have only one instance and set to `True`, all the expired items will not be auto-removed, when you call `GetItem` those expired items are filtred out.
+  In that case you are responsable to manually remove the expired key or update it
 
 3. Then pull from DI like any other service
 
@@ -48,15 +58,19 @@ In that case you are responsable to manually remove the expired key or update it
     }
 
 ```
-## What it does to my database 🐘: 
 
-1) Creates a table (name is configurable)
-2) Creates two functions
+## What it does to my database 🐘:
+
+1. Creates a table (name is configurable)
+2. Creates two functions
+
 ```
 [schemaName].datediff
 [schemaName].getcacheitemformat
 ```
-3) Creates four stored procedures
+
+3. Creates four stored procedures
+
 ```
 [schemaName].deletecacheitemformat
 [schemaName].deleteexpiredcacheitemsformat
@@ -67,41 +81,54 @@ In that case you are responsable to manually remove the expired key or update it
 For additional details please check the [scripts folder](./Extensions.Caching.PostgreSql/PostgreSqlScripts).
 
 ## Runing the console sample
+
 You will need a local postgresql server with this configuration:
+
 1. Server listening to port 5432 at localhost
 1. The password of your `postgres` account, if not attached already to your user.
 1. Clone this repo.
 1. Run the following commands inside `PostgreSqlCacheSample`:
+
 ```shell
 dotnet restore
 prepare-database.cmd -create
 dotnet run
 ```
+
 ![S](sample_project.gif)
 
-
 ## Runing the React+WebApi WebSample project
+
 You will need a local postgresql server with this configuration:
+
 1. Server listening to port 5432 at localhost
 1. The password of your `postgres` account, if not attached already to your user.
 1. You also need `npm` and `node` installed on your dev machine
 1. Clone this repo.
 1. Run the following commands inside `WebSample`:
+
 ```shell
 dotnet restore
 prepare-database.cmd -create
 dotnet run
 ```
+
 It takes some time to `npm` retore the packages, grab a ☕ while waiting...
 
 Then you can delete the database with:
+
 ```
 prepare-database.cmd -erase
 ```
+
 ## Change Log
+
+1. v4.0.0 - Add suport to .net 7
+   1. [BREAKING CHANGE] - Drop suport to .net 5
+   1. [BREAKING CHANGE] - Make use of procedures (won't work with PostgreSQL <= 10, use version 3)
 1. v3.1.2 - removed dependency for `IHostApplicationLifetime` if not supported on the platform: `AWS` for instance - issue #28
 1. v3.1.0 - Added log messages on `Debug` Level, multitarget .net5 and .net6, dropped support to netstandard2.0, fix sample to match multitarget and sample database.
-1. v3.0.2 - `CreateInfrastructure` also creates the schema issue #8 
+1. v3.0.2 - `CreateInfrastructure` also creates the schema issue #8
 1. v3.0.1 - `DisableRemoveExpired` configuration added; If `TRUE` the cache instance won`t delete expired items.
 1. v3.0
    1. [BREAKING CHANGE] - Direct instantiation not preferred
@@ -109,7 +136,8 @@ prepare-database.cmd -erase
 1. v2.0.x - Update everything to net5.0, more detailed sample project.
 1. v1.0.8 - Update to latest dependencies -
 
-
 # License
-* MIT
+
+- MIT
+
 ### This is a fork from [repo](https://github.com/wullemsb/Extensions.Caching.PostgreSQL)

--- a/WebSample/WebSample.csproj
+++ b/WebSample/WebSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
There are several changes:
- library migrated to netstandard2.0, because there is no reason to use any different target
- dropped support for net5.0 - it is not supported anymore
- some functions are now stored procedures, so postgres 11+ is supported
- added support for net7.0 - fixes #31
- removed error log in case of duplicates - this situation shouldn't raise errors, there is nothing special about that

I've run your samples and everything works, but also please test the lib by yourself. 