### PR TITLE
Add flag UpdateOnGetCacheItem to PostGreSqlCacheOptions

### DIFF
--- a/Extensions.Caching.PostgreSql/DatabaseOperations.cs
+++ b/Extensions.Caching.PostgreSql/DatabaseOperations.cs
@@ -16,6 +16,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
     internal sealed class DatabaseOperations : IDatabaseOperations
     {
         private readonly ILogger<DatabaseOperations> _logger;
+        private readonly bool _updateOnGetCacheItem;
 
         public DatabaseOperations(IOptions<PostgreSqlCacheOptions> options, ILogger<DatabaseOperations> logger)
         {
@@ -43,6 +44,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
             SqlCommands = new SqlCommands(cacheOptions.SchemaName, cacheOptions.TableName);
 
             this._logger = logger;
+            this._updateOnGetCacheItem = !cacheOptions.DisableUpdateOnGetCacheItem;
             if (cacheOptions.CreateInfrastructure)
             {
                 CreateSchemaAndTableIfNotExist();
@@ -187,10 +189,13 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
 
             using var connection = new NpgsqlConnection(ConnectionString);
 
-            var updateCacheItem = new CommandDefinition(
-                SqlCommands.UpdateCacheItemSql,
-                new ItemIdUtcNow { Id = key, UtcNow = utcNow });
-            connection.Execute(updateCacheItem);
+            if (_updateOnGetCacheItem)
+            {
+                var updateCacheItem = new CommandDefinition(
+                    SqlCommands.UpdateCacheItemSql,
+                    new ItemIdUtcNow { Id = key, UtcNow = utcNow });
+                connection.Execute(updateCacheItem);
+            }
 
             if (includeValue)
             {
@@ -210,11 +215,14 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
 
             await using var connection = new NpgsqlConnection(ConnectionString);
 
-            var updateCacheItem = new CommandDefinition(
-                SqlCommands.UpdateCacheItemSql,
-                new ItemIdUtcNow { Id = key, UtcNow = utcNow },
-                cancellationToken: cancellationToken);
-            await connection.ExecuteAsync(updateCacheItem);
+            if (_updateOnGetCacheItem)
+            {
+                var updateCacheItem = new CommandDefinition(
+                    SqlCommands.UpdateCacheItemSql,
+                    new ItemIdUtcNow { Id = key, UtcNow = utcNow },
+                    cancellationToken: cancellationToken);
+                await connection.ExecuteAsync(updateCacheItem);
+            }
 
             if (includeValue)
             {

--- a/Extensions.Caching.PostgreSql/PostGreSqlCacheOptions.cs
+++ b/Extensions.Caching.PostgreSql/PostGreSqlCacheOptions.cs
@@ -33,7 +33,7 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
         public string TableName { get; set; }
 
 		/// <summary>
-		/// If set to true will create table and functions if necessary every time an instance of PostgreSqlCache is created
+		/// If set to true will create table and functions if necessary every time an instance of PostgreSqlCache is created.
 		/// </summary>
 		public bool CreateInfrastructure { get; set; } = true;
 
@@ -45,10 +45,16 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
 
         /// <summary>
         /// If set to true this instance of the cache will not remove expired items. 
-        /// Maybe on multiple instances scenario sharing the same database another instance will be responsable for remove expired itens.
+        /// Maybe on multiple instances scenario sharing the same database another instance will be responsable for remove expired items.
         /// Default value is false.
         /// </summary>
         public bool DisableRemoveExpired { get; set; } = false;
+
+        /// <summary>
+        /// If set to true no update of ExpiresAtTime will be performed when getting a cache item.
+        /// Default value is false.
+        /// </summary>
+        public bool DisableUpdateOnGetCacheItem { get; set; } = false;
 
         PostgreSqlCacheOptions IOptions<PostgreSqlCacheOptions>.Value => this;
     }


### PR DESCRIPTION
Add a flag DisableUpdateOnGetCacheItem to PostGreSqlCacheOptions to make it possible to avoid update statements when getting a cache item.

This allows this package to be used on read-only databases.