### PR TITLE
Add AddDistributedPostgreSqlCache overload that provides the IServiceProvider

### DIFF
--- a/Extensions.Caching.PostgreSql/PostgreSqlCacheServiceCollectionExtensions.cs
+++ b/Extensions.Caching.PostgreSql/PostgreSqlCacheServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
 
 namespace Community.Microsoft.Extensions.Caching.PostgreSql
 {
@@ -12,6 +13,25 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
 	/// </summary>
 	public static class PostGreSqlCachingServicesExtensions
 	{
+		/// <summary>
+		/// Adds Community Microsoft PostgreSql distributed caching services to the specified <see cref="IServiceCollection" />
+		/// without configuration. Use an implementation of <see cref="IConfigureOptions{PostgreSqlCacheOptions}"/> for configuration.
+		/// </summary>
+		/// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+		/// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+		public static IServiceCollection AddDistributedPostgreSqlCache(this IServiceCollection services)
+		{
+			if (services == null)
+			{
+				throw new ArgumentNullException(nameof(services));
+			}
+
+			services.AddOptions();
+			AddPostgreSqlCacheServices(services);
+			
+			return services;
+		}
+		
 		/// <summary>
 		/// Adds Community Microsoft PostgreSql distributed caching services to the specified <see cref="IServiceCollection" />.
 		/// </summary>
@@ -34,6 +54,32 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
 			AddPostgreSqlCacheServices(services);
 			services.Configure(setupAction);
 
+			return services;
+		}
+
+		/// <summary>
+		/// Adds Community Microsoft PostgreSql distributed caching services to the specified <see cref="IServiceCollection" />.
+		/// </summary>
+		/// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+		/// <param name="setupAction">An <see cref="Action{IServiceProvider, PostgreSqlCacheOptions}"/> to configure the provided <see cref="PostgreSqlCacheOptions"/>.</param>
+		/// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+		public static IServiceCollection AddDistributedPostgreSqlCache(this IServiceCollection services, Action<IServiceProvider, PostgreSqlCacheOptions> setupAction)
+		{
+			if (services == null)
+			{
+				throw new ArgumentNullException(nameof(services));
+			}
+
+			if (setupAction == null)
+			{
+				throw new ArgumentNullException(nameof(setupAction));
+			}
+
+			services.AddOptions();
+			AddPostgreSqlCacheServices(services);
+			services.AddSingleton<IConfigureOptions<PostgreSqlCacheOptions>>(
+				sp => new ConfigureOptions<PostgreSqlCacheOptions>(opt => setupAction(sp, opt)));
+			
 			return services;
 		}
 

--- a/PostgreSqlCacheSample/Program.cs
+++ b/PostgreSqlCacheSample/Program.cs
@@ -27,6 +27,18 @@ namespace PostgreSqlCacheSample
 						// This means que every time starts the application the 
 						// creation of table and database functions will be verified.
 					})
+						
+					// if you need to resolve something from the serviceprovider for configuration
+					// use this overload
+					// services.AddDistributedPostgreSqlCache((serviceProvider, setup) =>
+					// {
+					//	// IConfiguration is used as an example here
+					// 	var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+					// 	setup.ConnectionString = configuration["ConnectionString"];
+					// 	setup.SchemaName = configuration["SchemaName"];
+					// 	setup.TableName = configuration["TableName"];
+					// 	setup.CreateInfrastructure = configuration.GetValue<bool>("CreateInfrastructure");
+					// })
                     .AddHostedService<Worker>();
 				});
 	}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,33 @@ services.AddDistributedPostgreSqlCache(setup =>
 })
 ```
 
+### Configuring with `IServiceProvider` access
+
+```c#
+services.AddDistributedPostgreSqlCache((serviceProvider, setup) =>
+{
+    // IConfiguration is used as an example here
+    var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+    setup.ConnectionString = configuration["ConnectionString"];
+    ...
+})
+```
+
+### Configuring via `IConfigureOptions<PostgreSqlCacheOptions>`
+
+use
+
+```c#
+services.AddDistributedPostgreSqlCache();
+```
+
+and implement and register 
+
+```c#
+IConfigureOptions<PostgreSqlCacheOptions>
+```
+
+
 ### `DisableRemoveExpired = True` use case:
 
 When you have 2 or more instances/microservices/processes and you just to leave one of them removing expired items.


### PR DESCRIPTION
Allows the configuration action via `AddDistributedPostgreSqlCache` extension method to use the `IServiceProvider` for use cases where one needs to resolve something at runtime in order to build the configuration.

Also provides a `AddDistributedPostgreSqlCache` overload without any setup action at all for the use case where one wants to implement `IConfigureOptions<PostgreSqlCacheOptions>` to handle the configuration. 
This avoids the rather awkward looking `services.AddDistributedPostgreSqlCache(_ => { })`.