### PR TITLE
Allow to specify NpgsqlDataSource factory instead of ConnectionString

### DIFF
--- a/Extensions.Caching.PostgreSql/PostGreSqlCacheOptions.cs
+++ b/Extensions.Caching.PostgreSql/PostGreSqlCacheOptions.cs
@@ -1,11 +1,24 @@
 ﻿using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Options;
 using System;
+using Npgsql;
 
 namespace Community.Microsoft.Extensions.Caching.PostgreSql
 {
 	public class PostgreSqlCacheOptions : IOptions<PostgreSqlCacheOptions>
     {
+        /// <summary>
+        /// The factory to create a NpgsqlDataSource instance.
+        /// Either <see cref="DataSourceFactory"/> or <see cref="ConnectionString"/> should be set.
+        /// </summary>
+        public Func<NpgsqlDataSource> DataSourceFactory { get; set; }
+
+        /// <summary>
+        /// The connection string to the database.
+        /// If <see cref="DataSourceFactory"/> not set, <see cref="ConnectionString"/> would be used to connect to the database.
+        /// </summary>
+        public string ConnectionString { get; set; }
+
         /// <summary>
         /// An abstraction to represent the clock of a machine in order to enable unit testing.
         /// </summary>
@@ -16,11 +29,6 @@ namespace Community.Microsoft.Extensions.Caching.PostgreSql
         /// Minimum allowed is 5 minutes.
         /// </summary>
         public TimeSpan? ExpiredItemsDeletionInterval { get; set; }
-
-        /// <summary>
-        /// The connection string to the database.
-        /// </summary>
-        public string ConnectionString { get; set; }
 
         /// <summary>
         /// The schema name of the table.


### PR DESCRIPTION
To make this more flexible, it would be nice to have a possibility to reuse Npgsql types already registered in DI e.g. using Npgsql.DependencyInjection package or Aspire.Npgsql.

The proposed approach is to add optional `Func<NpgsqlDataSource> DataSourceFactory { get; set; }` to `PostgreSqlCacheOptions`. If it is set, it would be used to create `NpgsqlConnection` instances.

So given Npgsql types registered in DI, adding distributed cache would be possible as follows:
```
services.AddDistributedPostgreSqlCache((serviceProvider, options) =>
{
    options.DataSourceFactory = serviceProvider.GetRequiredService<NpgsqlDataSource>;
    options.SchemaName = configuration["SchemaName"];
    options.TableName = configuration["TableName"];
});
```