### PR TITLE
Updated dependencies for net8.0

### DIFF
--- a/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
+++ b/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="16.0">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>Community.Microsoft.Extensions.Caching.PostgreSql</AssemblyName>
     <RootNamespace>Community.Microsoft.Extensions.Caching.PostgreSql</RootNamespace>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>5.0.0</Version>
+    <Version>8.0.0</Version>
     <Authors>Ashley Marques</Authors>
     <Company />
     <Description>DistributedCache using postgres</Description>

--- a/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
+++ b/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
@@ -25,12 +25,20 @@
     <Compile Include="**\*.cs" />
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>-->
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageReference Include="Npgsql" Version="9.0.2" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="[8.*,9)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.*,9)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.*,9)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[8.*,9)" />
+    <PackageReference Include="Npgsql" Version="[8.*,9)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It doesn't work for net8.0 because the Npgsql v9 is not compatible with net8.0.
I added a separate ItemGroup to handle this case. You may want to do this other target frameworks but I did for net8 because it is LTS.