### PR TITLE
Use target framework specific Npgsql package

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -14,6 +14,10 @@ on:
 jobs:
   build-test-coverage:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ["8.0.x", "9.0.x", "10.0.x"]
+      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,10 +30,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Restore dependencies
         run: dotnet restore
@@ -58,7 +59,7 @@ jobs:
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-${{ matrix.dotnet-version }}
           path: ./TestResults/*.trx
 
       - name: Publish Test Results
@@ -82,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: env.COVERAGE_FILE_PATH != ''
         with:
-          name: coverage-report
+          name: coverage-report-${{ matrix.dotnet-version }}
           path: ${{ env.COVERAGE_FILE_PATH }}
 
       - name: Generate Coverage Report
@@ -98,7 +99,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: env.COVERAGE_FILE_PATH != ''
         with:
-          name: html-coverage-report
+          name: html-coverage-report-${{ matrix.dotnet-version }}
           path: ./TestResults/coverage/report
 
       - name: Display Coverage Summary

--- a/CachingTest/CachingTest.csproj
+++ b/CachingTest/CachingTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
+++ b/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
@@ -23,17 +23,13 @@
     <None Include="..\CONTRIBUTING.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <!-- Common package references for all frameworks -->
-  <ItemGroup>
-    <PackageReference Include="Npgsql" Version="10.0.0" />
-  </ItemGroup>
-
   <!-- Framework-specific package references -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Npgsql" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -41,6 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageReference Include="Npgsql" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
@@ -48,6 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageReference Include="Npgsql" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
+++ b/Extensions.Caching.PostgreSql/Community.Microsoft.Extensions.Caching.PostgreSql.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageReference Include="Npgsql" Version="8.0.0" />
+    <PackageReference Include="Npgsql" Version="8.0.8" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageReference Include="Npgsql" Version="9.0.0" />
+    <PackageReference Include="Npgsql" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">


### PR DESCRIPTION
I had the issue that I could not use the latest version of `Community.Microsoft.Extensions.Caching.PostgreSQL` in a .NET 8 application, because of a conflict of  `Npgsql` with `Npgsql.EntityFrameworkCore.PostgreSQL`.

This should fix this.