### PR TITLE
Run tests across .NET versions using a CI matrix

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -3,7 +3,6 @@ name: .NET Test & Coverage
 permissions:
   checks: write
   contents: read
-  issues: write
 
 on:
   push:
@@ -39,11 +38,11 @@ jobs:
         run: dotnet build --no-restore --configuration Release
 
       - name: Pull PostgreSQL Docker image
-        run: docker pull postgres:latest
+        run: docker pull postgres:17
 
       - name: Test with coverage
         env:
-          # Testcontainers configuration for CI
+          # Ryuk cleanup is kept privileged so failed CI runs still remove sibling Docker resources.
           TESTCONTAINERS_RYUK_DISABLED: false
           TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED: true
           DOCKER_HOST: unix:///var/run/docker.sock


### PR DESCRIPTION
## Summary

- Runs the `.NET Test & Coverage` workflow in parallel across .NET 8, 9, and 10 using a GitHub Actions matrix (`fail-fast: false`).
- Installs one SDK per job via `${{ matrix.dotnet-version }}` instead of installing all SDKs in a single job.
- Names test and coverage artifacts per .NET version to avoid collisions between matrix jobs.
- Pins the PostgreSQL test image to `postgres:17` and drops unused `issues: write` workflow permission.

**Note:** The matrix strategy itself was already merged upstream in #100. This PR includes that behavior plus the small CI hardening tweaks above.

## Test plan

- [ ] Confirm GitHub Actions runs three parallel jobs for `8.0.x`, `9.0.x`, and `10.0.x`
- [ ] Verify all matrix jobs pass on Ubuntu with Testcontainers
- [ ] Confirm artifacts are uploaded as `test-results-<version>`, `coverage-report-<version>`, and `html-coverage-report-<version>`
- [ ] Confirm coverage summaries appear independently in each job log without conflicts